### PR TITLE
add assert validation on dates for offers

### DIFF
--- a/app/src/Entity/Offer.php
+++ b/app/src/Entity/Offer.php
@@ -5,6 +5,7 @@ namespace App\Entity;
 use Doctrine\ORM\Mapping as ORM;
 use App\Repository\OfferRepository;
 use Doctrine\ORM\Mapping\JoinColumn;
+use Symfony\Component\Validator\Constraints as Assert;
 
 /**
  * @ORM\Entity(repositoryClass=OfferRepository::class)
@@ -21,11 +22,13 @@ class Offer
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Assert\NotBlank
      */
     private $name;
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Assert\NotBlank 
      */
     private $description;
 
@@ -42,11 +45,15 @@ class Offer
 
     /**
      * @ORM\Column(type="datetimetz")
+     *@Assert\GreaterThanOrEqual("tomorrow", message="Une offre peut commencer qu'à partir de demain.")
+     *@Assert\LessThanOrEqual(propertyPath="dateEnd", message="La date de commencement doit être inférieure à la date de fin.")
      */
     private $dateStart;
 
     /**
      * @ORM\Column(type="datetimetz")
+     *@Assert\GreaterThanOrEqual("tomorrow")
+     *@Assert\GreaterThanOrEqual(propertyPath="dateStart", message="La date de fin doit être supérieure à la date de commencement.")
      */
     private $dateEnd;
 

--- a/app/src/Entity/Offer.php
+++ b/app/src/Entity/Offer.php
@@ -35,6 +35,7 @@ class Offer
     /**
      * @ORM\ManyToOne(targetEntity=Brand::class)
      * @JoinColumn(onDelete="CASCADE")
+     * @Assert\NotNull
      */
     private $brandId;
 

--- a/app/src/Entity/Offer.php
+++ b/app/src/Entity/Offer.php
@@ -47,6 +47,7 @@ class Offer
     /**
      * @ORM\Column(type="datetimetz")
      *@Assert\GreaterThanOrEqual("tomorrow", message="Une offre peut commencer qu'à partir de demain.")
+     *@Assert\GreaterThan(propertyPath="dateCreation", message="Une offre ne peut pas être inférieure à la date de publication.")
      *@Assert\LessThanOrEqual(propertyPath="dateEnd", message="La date de commencement doit être inférieure à la date de fin.")
      */
     private $dateStart;
@@ -55,6 +56,10 @@ class Offer
      * @ORM\Column(type="datetimetz")
      *@Assert\GreaterThanOrEqual("tomorrow")
      *@Assert\GreaterThanOrEqual(propertyPath="dateStart", message="La date de fin doit être supérieure à la date de commencement.")
+     * @Assert\Range(
+     *      minPropertyPath = "dateStart",
+     *      max = "+5 years"
+     * )
      */
     private $dateEnd;
 
@@ -143,11 +148,11 @@ class Offer
 
     public function getDateEnd(): ?\DateTimeInterface
     {
-        return $this->dateEnd;
+        return $this->dateEnd ;
     }
 
     public function setDateEnd(\DateTimeInterface $dateEnd): self
-    {
+    {  
         $this->dateEnd = $dateEnd;
 
         return $this;


### PR DESCRIPTION
Vérification des dates d'une offre
Les champs name et description sont obligatoires lors de la création d'une offre
Vérifier si la date de début de l'offre est bien supérieure à la date de publication
Vérifier qu'une offre ne doit pas excéder plus de 5 ans dans le temps.